### PR TITLE
ProductListItemsValueResolver null check

### DIFF
--- a/Merchello.UkFest.Web/Ditto/ValueResolvers/ProductListItemsValueResolver.cs
+++ b/Merchello.UkFest.Web/Ditto/ValueResolvers/ProductListItemsValueResolver.cs
@@ -30,6 +30,8 @@
 
             var products = Content.GetPropertyValue<IEnumerable<IProductContent>>("products");
 
+            if (products == null) return empty;
+
             return products.Select(x => x.AsProductListItem());
         }
     }


### PR DESCRIPTION
When I first ran the website from the "dev" branch, I got a YSoD about `products` being null. So I added in a null-reference check.

When I checked the back-office, on the "Home" node, the "products" field threw an exception in the right-side dialog panel...

```
Received an error from the server
Failed to get colleciton entities

Object reference not set to an instance of an object.

System.NullReferenceException: Object reference not set to an instance of an object.
STACKTRACE:

at Merchello.Web.WebApi.JsonCamelCaseFormatter.OnActionExecuted(HttpActionExecutedContext httpActionExecutedContext) in c:\Working Repositories\GitHub\Merchello\src\Merchello.Web\WebApi\JsonCamelCaseFormatter.cs:line 40
```

I'm probably missing some data?
